### PR TITLE
Add user-toggleable dark mode

### DIFF
--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -71,6 +72,7 @@ class UserController extends Controller {
         $notifCommenter = $request->get('notif_commenter') ? true : false;
         $notifMention = $request->get('notif_mention') ? true : false;
         $shareDecks = $request->get('share_decks') ? true : false;
+        $darkMode = $request->get('dark_mode') ? true : false;
 
         $user->setColor($sphere_code);
         $user->setResume($resume);
@@ -78,12 +80,20 @@ class UserController extends Controller {
         $user->setIsNotifCommenter($notifCommenter);
         $user->setIsNotifMention($notifMention);
         $user->setIsShareDecks($shareDecks);
+        $user->setDarkMode($darkMode);
 
         $this->getDoctrine()->getManager()->flush();
 
         $this->get('session')->getFlashBag()->set('notice', 'Successfully saved your profile.');
 
-        return $this->redirect($this->generateUrl('user_profile_edit'));
+        $response = $this->redirect($this->generateUrl('user_profile_edit'));
+
+        // Persist the preference in a long-lived cookie so the theme can be applied
+        // immediately (without a flash of the wrong theme) on this device, even though
+        // pages are publicly cached and the canonical preference lives in the database.
+        $response->headers->setCookie(new Cookie('dark_mode', $darkMode ? '1' : '0', strtotime('+1 year'), '/', null, false, false));
+
+        return $response;
     }
 
     public function infoAction(Request $request) {
@@ -112,7 +122,8 @@ class UserController extends Controller {
                 'name' => $user->getUsername(),
                 'sphere' => $user->getColor(),
                 'donation' => $user->getDonation(),
-                'owned_packs' => $user->getOwnedPacks()
+                'owned_packs' => $user->getOwnedPacks(),
+                'dark_mode' => $user->getDarkMode()
             ];
 
             if (isset($decklist_id)) {

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -62,6 +62,10 @@ class User extends BaseUser {
      */
     private $isShareDecks = false;
     /**
+     * @var boolean
+     */
+    private $darkMode = false;
+    /**
      * @var \Doctrine\Common\Collections\Collection
      */
     private $decks;
@@ -359,6 +363,28 @@ class User extends BaseUser {
      */
     public function getIsShareDecks() {
         return $this->isShareDecks;
+    }
+
+    /**
+     * Set darkMode
+     *
+     * @param boolean $darkMode
+     *
+     * @return User
+     */
+    public function setDarkMode($darkMode) {
+        $this->darkMode = $darkMode;
+
+        return $this;
+    }
+
+    /**
+     * Get darkMode
+     *
+     * @return boolean
+     */
+    public function getDarkMode() {
+        return $this->darkMode;
     }
 
     /**

--- a/src/AppBundle/Resources/config/doctrine/User.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/User.orm.yml
@@ -148,6 +148,12 @@ AppBundle\Entity\User:
             column: is_share_decks
             options:
                 default: false
+        darkMode:
+            type: boolean
+            nullable: false
+            column: dark_mode
+            options:
+                default: false
         ownedPacks:
             type: string
             length: 512

--- a/src/AppBundle/Resources/public/css/dark.scss
+++ b/src/AppBundle/Resources/public/css/dark.scss
@@ -1,0 +1,297 @@
+/*
+ * Dark mode theme.
+ *
+ * Activated by the `dark-mode` class on the <html> element (set from the user's
+ * account preference via a cookie + the user-info JSON; see layout.html.twig and
+ * app.user.js). Everything here is scoped under `.dark-mode` so the default light
+ * theme is untouched. We only override surfaces, borders and text colors -- card
+ * images and sphere colors are intentionally left alone.
+ */
+
+$dark-bg: #1a1a1d;
+$dark-surface: #242428;
+$dark-surface-2: #2e2e33;
+$dark-surface-3: #38383f;
+$dark-border: #3d3d44;
+$dark-text: #d6d6d6;
+$dark-text-muted: #9a9a9a;
+$dark-link: #6ea8e0;
+$dark-link-hover: #9cc6ee;
+
+.dark-mode {
+  background-color: $dark-bg;
+
+  body {
+    background-color: $dark-bg;
+    color: $dark-text;
+  }
+
+  a {
+    color: $dark-link;
+
+    &:hover,
+    &:focus {
+      color: $dark-link-hover;
+    }
+  }
+
+  hr {
+    border-top-color: $dark-border;
+  }
+
+  .text-muted,
+  .help-block,
+  .text-faded {
+    color: $dark-text-muted;
+  }
+
+  /********* NAVBAR ************/
+
+  .navbar-default {
+    background-color: $dark-surface;
+    border-color: $dark-border;
+
+    .navbar-brand,
+    .navbar-text {
+      color: $dark-text;
+    }
+
+    .navbar-nav > li > a {
+      color: $dark-text;
+
+      &:hover,
+      &:focus {
+        color: $dark-link-hover;
+      }
+    }
+
+    .navbar-nav > .active > a,
+    .navbar-nav > .open > a {
+      color: $dark-link-hover;
+      background-color: $dark-surface-2;
+    }
+
+    .navbar-toggle {
+      border-color: $dark-border;
+
+      .icon-bar {
+        background-color: $dark-text;
+      }
+
+      &:hover,
+      &:focus {
+        background-color: $dark-surface-2;
+      }
+    }
+  }
+
+  /********* PANELS / WELLS ************/
+
+  .panel {
+    background-color: $dark-surface;
+    border-color: $dark-border;
+  }
+
+  .panel-default > .panel-heading {
+    background-color: $dark-surface-2;
+    border-color: $dark-border;
+    color: $dark-text;
+  }
+
+  .panel-footer {
+    background-color: $dark-surface-2;
+    border-color: $dark-border;
+  }
+
+  .well {
+    background-color: $dark-surface;
+    border-color: $dark-border;
+  }
+
+  /********* TABLES ************/
+
+  .table {
+    color: $dark-text;
+
+    > thead > tr > th,
+    > tbody > tr > th,
+    > tfoot > tr > th,
+    > thead > tr > td,
+    > tbody > tr > td,
+    > tfoot > tr > td {
+      border-color: $dark-border;
+    }
+
+    > thead > tr > th {
+      border-bottom-color: $dark-border;
+    }
+  }
+
+  .table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: $dark-surface-2;
+  }
+
+  .table-hover > tbody > tr:hover {
+    background-color: $dark-surface-3;
+  }
+
+  .table-bordered,
+  .table-bordered > thead > tr > th,
+  .table-bordered > tbody > tr > td {
+    border-color: $dark-border;
+  }
+
+  /********* FORMS ************/
+
+  .form-control {
+    background-color: $dark-surface-2;
+    border-color: $dark-border;
+    color: $dark-text;
+
+    &:focus {
+      border-color: $dark-link;
+    }
+  }
+
+  .form-control[disabled],
+  .form-control[readonly],
+  fieldset[disabled] .form-control {
+    background-color: $dark-surface;
+  }
+
+  ::-webkit-input-placeholder { color: $dark-text-muted; }
+  :-moz-placeholder { color: $dark-text-muted; }
+  ::-moz-placeholder { color: $dark-text-muted; }
+  :-ms-input-placeholder { color: $dark-text-muted; }
+
+  .input-group-addon {
+    background-color: $dark-surface-3;
+    border-color: $dark-border;
+    color: $dark-text;
+  }
+
+  /********* BUTTONS ************/
+
+  .btn-default {
+    background-color: $dark-surface-3;
+    border-color: $dark-border;
+    color: $dark-text;
+
+    &:hover,
+    &:focus,
+    &:active {
+      background-color: $dark-surface-2;
+      border-color: $dark-border;
+      color: $dark-text;
+    }
+  }
+
+  /********* DROPDOWNS ************/
+
+  .dropdown-menu {
+    background-color: $dark-surface;
+    border-color: $dark-border;
+
+    > li > a {
+      color: $dark-text;
+
+      &:hover,
+      &:focus {
+        background-color: $dark-surface-2;
+        color: $dark-link-hover;
+      }
+    }
+
+    .divider {
+      background-color: $dark-border;
+    }
+  }
+
+  /********* LIST GROUPS ************/
+
+  .list-group-item {
+    background-color: $dark-surface;
+    border-color: $dark-border;
+    color: $dark-text;
+  }
+
+  a.list-group-item:hover,
+  a.list-group-item:focus {
+    background-color: $dark-surface-2;
+    color: $dark-link-hover;
+  }
+
+  /********* MODALS ************/
+
+  .modal-content {
+    background-color: $dark-surface;
+    border-color: $dark-border;
+  }
+
+  .modal-header,
+  .modal-footer {
+    border-color: $dark-border;
+  }
+
+  /********* CODE ************/
+
+  code,
+  pre {
+    background-color: $dark-surface-2;
+    border-color: $dark-border;
+    color: $dark-text;
+  }
+
+  /********* APP SPECIFICS ************/
+
+  .card-text {
+    border-left-color: $dark-border;
+  }
+
+  .nav-tabs {
+    border-bottom-color: $dark-border;
+
+    > li > a:hover {
+      border-color: $dark-border $dark-border $dark-border;
+      background-color: $dark-surface-2;
+    }
+
+    > li.active > a,
+    > li.active > a:hover,
+    > li.active > a:focus {
+      background-color: $dark-surface;
+      border-color: $dark-border;
+      border-bottom-color: transparent;
+      color: $dark-text;
+    }
+  }
+
+  .pagination {
+    > li > a,
+    > li > span {
+      background-color: $dark-surface;
+      border-color: $dark-border;
+      color: $dark-link;
+    }
+
+    > li > a:hover,
+    > li > span:hover {
+      background-color: $dark-surface-2;
+    }
+
+    > .disabled > a,
+    > .disabled > span {
+      background-color: $dark-surface;
+      border-color: $dark-border;
+      color: $dark-text-muted;
+    }
+  }
+
+  footer {
+    color: $dark-text-muted;
+
+    a {
+      color: $dark-link;
+    }
+  }
+}

--- a/src/AppBundle/Resources/public/css/dark.scss
+++ b/src/AppBundle/Resources/public/css/dark.scss
@@ -275,6 +275,24 @@ $dark-link-hover: #9cc6ee;
     background-color: $dark-surface-2;
   }
 
+  /* Play simulator: darker, hue-preserving versions of the sphere-colored
+     draggable card rows, which are light pastels by default. */
+  .tab-card-leadership  { background-color: #4a2f4d; }
+  .tab-card-lore        { background-color: #2d4628; }
+  .tab-card-spirit      { background-color: #1f4250; }
+  .tab-card-tactics     { background-color: #4d2526; }
+  .tab-card-baggins     { background-color: #4a3f1c; }
+  .tab-card-fellowship  { background-color: #4a3214; }
+  .tab-card-neutral     { background-color: #3a3a40; }
+
+  .card-title {
+    color: $dark-text;
+  }
+
+  .tab-card-border-facedown {
+    background-color: $dark-surface-3;
+  }
+
   .card-text {
     border-left-color: $dark-border;
   }

--- a/src/AppBundle/Resources/public/css/dark.scss
+++ b/src/AppBundle/Resources/public/css/dark.scss
@@ -271,6 +271,10 @@ $dark-link-hover: #9cc6ee;
     color: $dark-text;
   }
 
+  .row.title {
+    background-color: $dark-surface-2;
+  }
+
   .card-text {
     border-left-color: $dark-border;
   }

--- a/src/AppBundle/Resources/public/css/dark.scss
+++ b/src/AppBundle/Resources/public/css/dark.scss
@@ -244,6 +244,33 @@ $dark-link-hover: #9cc6ee;
 
   /********* APP SPECIFICS ************/
 
+  .container.main {
+    &.white {
+      background-color: $dark-surface;
+    }
+
+    &.admin {
+      background-color: $dark-surface;
+    }
+  }
+
+  /* Typeahead (card search autocomplete) */
+  .twitter-typeahead {
+    background-color: $dark-surface-2;
+
+    .tt-hint {
+      color: $dark-text-muted;
+    }
+  }
+
+  .tt-menu,
+  .tt-dropdown-menu {
+    background-color: $dark-surface;
+    border-color: $dark-border;
+    border-color: rgba(255, 255, 255, .15);
+    color: $dark-text;
+  }
+
   .card-text {
     border-left-color: $dark-border;
   }

--- a/src/AppBundle/Resources/public/css/dark.scss
+++ b/src/AppBundle/Resources/public/css/dark.scss
@@ -293,6 +293,16 @@ $dark-link-hover: #9cc6ee;
     background-color: $dark-surface-3;
   }
 
+  /* Brighten the resource/damage counter numbers so they stay legible on
+     the darkened rows (defaults are dark blue / dark red). */
+  .container-resources {
+    color: rgb(120, 150, 255);
+  }
+
+  .container-damage {
+    color: rgb(255, 110, 110);
+  }
+
   .card-text {
     border-left-color: $dark-border;
   }

--- a/src/AppBundle/Resources/public/css/dark.scss
+++ b/src/AppBundle/Resources/public/css/dark.scss
@@ -275,6 +275,27 @@ $dark-link-hover: #9cc6ee;
     background-color: $dark-surface-2;
   }
 
+  /* The index-page title logo is a black PNG (transparent background), which is
+     invisible on a dark background. Recolor it to gold by using the image as a
+     mask and painting gold behind it. The source is 1440x528, so the box keeps
+     that aspect ratio while staying responsive (max 500px wide, same as the img). */
+  h1.site-title {
+    img {
+      display: none;
+    }
+
+    &::after {
+      content: "";
+      display: inline-block;
+      width: 500px;
+      max-width: 100%;
+      aspect-ratio: 1440 / 528;
+      background-color: #d4af37;
+      -webkit-mask: url(https://i.imgur.com/8jg53Dt.png) center / contain no-repeat;
+      mask: url(https://i.imgur.com/8jg53Dt.png) center / contain no-repeat;
+    }
+  }
+
   /* Play simulator: darker, hue-preserving versions of the sphere-colored
      draggable card rows, which are light pastels by default. */
   .tab-card-leadership  { background-color: #4a2f4d; }

--- a/src/AppBundle/Resources/public/css/style.scss
+++ b/src/AppBundle/Resources/public/css/style.scss
@@ -998,6 +998,11 @@ h1.site-title {
   font-size: 116px;
   text-align: center;
   margin-top: 0;
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
 }
 
 @media (max-width: 767px) {

--- a/src/AppBundle/Resources/public/js/app.deck_charts.js
+++ b/src/AppBundle/Resources/public/js/app.deck_charts.js
@@ -32,6 +32,42 @@
         return format.substring(0, format.length - value.length) + value;
     };
 
+    // When dark mode is on, theme the charts to match (background + text colors).
+    // Highcharts 4.x renders these as inline SVG styles, so CSS alone can't override
+    // them reliably -- setOptions applies to every chart created afterwards. Palette
+    // mirrors dark.scss.
+    if (typeof Highcharts !== 'undefined' && $('html').hasClass('dark-mode')) {
+        Highcharts.setOptions({
+            chart: { backgroundColor: '#242428' },
+            title: { style: { color: '#d6d6d6' } },
+            subtitle: { style: { color: '#9a9a9a' } },
+            xAxis: {
+                lineColor: '#3d3d44',
+                tickColor: '#3d3d44',
+                gridLineColor: '#3d3d44',
+                labels: { style: { color: '#d6d6d6' } },
+                title: { style: { color: '#9a9a9a' } }
+            },
+            yAxis: {
+                lineColor: '#3d3d44',
+                tickColor: '#3d3d44',
+                gridLineColor: '#3d3d44',
+                labels: { style: { color: '#d6d6d6' } },
+                title: { style: { color: '#9a9a9a' } }
+            },
+            legend: {
+                itemStyle: { color: '#d6d6d6' },
+                itemHoverStyle: { color: '#ffffff' }
+            },
+            tooltip: {
+                backgroundColor: 'rgba(0, 0, 0, 0.85)',
+                style: { color: '#d6d6d6' }
+            },
+            plotOptions: { series: { dataLabels: { color: '#d6d6d6' } } },
+            labels: { style: { color: '#d6d6d6' } }
+        });
+    }
+
 
     deck_charts.chart_sphere = function chart_sphere() {
         var spheres = {};

--- a/src/AppBundle/Resources/public/js/app.user.js
+++ b/src/AppBundle/Resources/public/js/app.user.js
@@ -75,14 +75,30 @@
      */
     user.anonymous = function anonymous() {
         user.wipe();
+        user.apply_dark_mode();
         user.dropdown('<ul class="dropdown-menu"><li><a href="' + Routing.generate('fos_user_security_login') + '">Login or Register</a></li></ul>');
     };
 
     /**
      * @memberOf user
      */
+    /**
+     * Apply the dark mode preference coming from the user's account, keeping the
+     * <html> class and the cookie in sync. The cookie lets the inline script in the
+     * page <head> apply the theme before paint on the next load (no flash).
+     * @memberOf user
+     */
+    user.apply_dark_mode = function apply_dark_mode() {
+        var enabled = !!(user.data && user.data.dark_mode);
+        $('html').toggleClass('dark-mode', enabled);
+        var expires = new Date();
+        expires.setFullYear(expires.getFullYear() + 1);
+        document.cookie = 'dark_mode=' + (enabled ? '1' : '0') + '; expires=' + expires.toUTCString() + '; path=/';
+    };
+
     user.update = function update() {
         user.store();
+        user.apply_dark_mode();
         user.dropdown('<ul class="dropdown-menu">' +
             '<li><a href="' + Routing.generate('user_profile_edit') + '">Edit account</a></li>' +
             '<li><a href="' + user.data.public_profile_url + '">Public profile</a></li>' +

--- a/src/AppBundle/Resources/views/Default/index.html.twig
+++ b/src/AppBundle/Resources/views/Default/index.html.twig
@@ -7,6 +7,12 @@
         <h1 class="site-title"><img src="https://i.imgur.com/8jg53Dt.png" alt="RingsDB" width="500"></h1>
         <div class="site-slogan hidden-xs">Deckbuilder for The Lord of the Rings (<b>Physical</b> / <a href="https://digital.ringsdb.com">Digital</a>) LCG</div>
 
+        <div id="dark-mode-promo" class="alert alert-info alert-dismissible text-center" style="display: none;">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <span class="fa fa-moon-o"></span>
+            Try out the new <strong>Dark Mode</strong>! Enable it on your <a href="{{ path('user_profile_edit') }}">account page</a>.
+        </div>
+
 	{# <center>You can contribute to the continued development of RingsDB on <a href="https://www.patreon.com/Seastan" target="_blank">Patreon</a>.</center> #}
 	<div style="position:relative; text-align: center; padding-top: 10px;">{{ daily_challenge }}</div>
 
@@ -290,6 +296,16 @@
 {% endblock %}
 
 {% block javascripts %}
+    <script type="text/javascript">
+        // Show the dark mode promo only to logged-in users who haven't enabled it.
+        // Login state is loaded client-side (see app.user.js) since the page is cached.
+        app.user.loaded.done(function() {
+            if (app.user.data && !app.user.data.dark_mode) {
+                $('#dark-mode-promo').show();
+            }
+        });
+    </script>
+
     <script type="application/ld+json">
         {
            "@context": "http://schema.org",

--- a/src/AppBundle/Resources/views/User/profile_edit.html.twig
+++ b/src/AppBundle/Resources/views/User/profile_edit.html.twig
@@ -72,6 +72,16 @@
                                 </p>
                             </div>
 
+                            <div class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="dark_mode" value="1" {% if user.darkMode %}checked{% endif %}>
+                                    Dark mode
+                                </label>
+                                <p class="help-block">
+                                    Use a dark color theme across the site. The setting follows your account, so it will apply on any device where you are logged in.
+                                </p>
+                            </div>
+
                             <div class="form-group">
                                 <label for="color">Select a sphere color for your username</label>
                                 {% for sphere in spheres %}

--- a/src/AppBundle/Resources/views/layout.html.twig
+++ b/src/AppBundle/Resources/views/layout.html.twig
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script type="text/javascript">
+        // Apply the dark theme as early as possible to avoid a flash of the light theme.
+        // The preference is stored in a cookie (mirrored from the user's account) so it
+        // works even though pages are publicly cached.
+        (function() {
+            if (/(?:^|;\s*)dark_mode=1(?:;|$)/.test(document.cookie)) {
+                document.documentElement.className += ' dark-mode';
+            }
+        })();
+    </script>
     <title>{{ pagetitle | default('Deckbuilder') }} &middot; RingsDB</title>
 
     <meta charset="utf-8">
@@ -26,7 +36,8 @@
         'bundles/app/cdn/css/bootstrap-markdown.min.css'
         'bundles/app/css/bootstrap.css'
         'bundles/app/css/style.scss'
-        'bundles/app/css/icons.scss' %}
+        'bundles/app/css/icons.scss'
+        'bundles/app/css/dark.scss' %}
         <link rel="stylesheet" href="{{ asset_url }}"/>
     {% endstylesheets %}
 


### PR DESCRIPTION
Add a dark mode that users can enable from their profile page. The preference is stored on the user account (dark_mode column) and applied client-side via a cookie + the user-info JSON, so it works with the existing public page caching and across devices without a flash of the light theme.

Requires a schema update: ALTER TABLE user ADD dark_mode TINYINT(1) NOT NULL DEFAULT 0; and an assetic:dump to compile dark.scss.